### PR TITLE
remove reference to now-removed translation support

### DIFF
--- a/s/index.md
+++ b/s/index.md
@@ -46,13 +46,6 @@ Don't see a language that you'd like to see represented? Please let me know if y
 * Add an issue in the [issue tracker](http://github.com/petdance/bobby-tables/issues).
 * Email me, Andy Lester, at andy at petdance.com.
 
-Translations also welcome
-=========================
-
-Help translate this site! There are only 100 phrases. No programming necessary.
-
-See the instructions at the [bobby-tables repository at github](http://github.com/petdance/bobby-tables#readme).
-
 To do
 =====
 


### PR DESCRIPTION
no need to tantalize people with a reference to translation infrastructure that no longer exists

just curious what the reasons were for removing it (other than inability to keep it up to date) - was it dependence on Textile markup to generate the PO files?
