### PR TITLE
Script version of cfquery and queryExecute added

### DIFF
--- a/s/coldfusion.md
+++ b/s/coldfusion.md
@@ -31,3 +31,35 @@ have a slightly different syntax, but still provide parameterized queries.
       var rawQuery = myQuery.execute().getResult();
     </cfscript>
 
+Alternative script syntaxes include:
+
+    <cfscript>
+      query name="myQuery" {
+        echo("
+          SELECT FirstName, LastName, Phone
+          FROM   tblUser
+          WHERE  Status
+        ");
+        queryparam sqltype="varchar" value="#form.status#";
+      }
+    </cfscript>
+
+And as of Railo 4.2.1, queryExecute allows both named parameters and positional parameters:
+
+    <cfscript>
+      // Named
+      myQuery = queryExecute(
+        "SELECT FirstName, LastName, Phone
+        FROM   tblUser
+        WHERE  Status = :status",
+        {status = {value = form.status, sqltype="varchar"}}
+      );
+
+      // Positional
+      myQuery = queryExecute(
+        "SELECT FirstName, LastName, Phone
+        FROM   tblUser
+        WHERE  Status = ?",
+        [{value = form.status, sqltype="varchar"}]
+      );
+    </cfscript>


### PR DESCRIPTION
Tested on Railo 4.2.1. queryExecute is new to that version so I though it was worth mentioning.
