### PR TITLE
Add link to Czech localization

### DIFF
--- a/tt/translations.tt
+++ b/tt/translations.tt
@@ -1,3 +1,5 @@
+<a href="http://bobby-tables.cz/[% section %]" xml:lang="cs-CZ" lang="cs-CZ" hreflang="cs-CZ">Čeština</a>
+/
 <a href="[% rel_static %]de_DE/[% section %]" xml:lang="de-DE" lang="de-DE" hreflang="de-DE">Deutsch</a>
 /
 <a href="[% rel_static %]ru_RU/[% section %]" xml:lang="ru-RU" lang="ru-RU" hreflang="ru-RU">Русский язык</a>


### PR DESCRIPTION
I have created the Czech translation of bobby-tables.com and published it at http://bobby-tables.cz/

It would be great if you could add a link to the translation into the footer at bobby-tables.com.
