### PR TITLE
Add Dockerfile for generating site from a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM perl
+
+# Install necessary perl modules
+RUN cpanm File::Slurp
+RUN cpanm Locale::Messages
+RUN cpanm Locale::TextDomain
+RUN cpanm Locale::Maketext::Lexicon
+RUN cpanm Template
+RUN cpanm Text::Markdown
+RUN cpanm URI
+RUN cpanm Test::HTML::Lint --force
+
+# Install cli tools used by makefile
+RUN apt-get update && apt-get install -y \
+    gettext \
+    locales
+
+# Uncomment any lines starting with our desired locales then generate them
+RUN sed -i 's/^# \(de_DE\|es_AR\|ru_RU\)/\1/' /etc/locale.gen && locale-gen
+
+WORKDIR /app
+CMD ["make"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,19 @@
-FROM perl
+FROM debian:buster-slim
+
+## Install perl, tooling, and dependencies for perl modules
+RUN apt-get update && apt-get install -y \
+    cpanminus \
+    gcc \
+    libtidy-dev \
+    make \
+    perl \
+  && rm -fr /var/lib/apt/lists/*
 
 # Install necessary perl modules
 RUN cpanm File::Slurp
-RUN cpanm Locale::Messages
-RUN cpanm Locale::TextDomain
-RUN cpanm Locale::Maketext::Lexicon
+RUN cpanm Markdent
 RUN cpanm Template
-RUN cpanm Text::Markdown
-RUN cpanm URI
-RUN cpanm Test::HTML::Lint --force
-
-# Install cli tools used by makefile
-RUN apt-get update && apt-get install -y \
-    gettext \
-    locales
-
-# Uncomment any lines starting with our desired locales then generate them
-RUN sed -i 's/^# \(de_DE\|es_AR\|ru_RU\)/\1/' /etc/locale.gen && locale-gen
+RUN cpanm Test::HTML::Tidy5
 
 WORKDIR /app
 CMD ["make"]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ For testing:
 
 * Test::HTML::Tidy5
 
+Alternatively a Dockerfile is provided which can run the necessary make tasks
+in a container.
+
+    docker build -t bobby-tables .                      # Builds the container
+    docker run --rm -v $PWD=/app bobby-tables           # Builds the site
+    docker run --rm -v $PWD=/app bobby-tables make test # Runs the tests
+
 Contributing page content
 -------------------------
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Alternatively a Dockerfile is provided which can run the necessary make tasks
 in a container.
 
     docker build -t bobby-tables .                      # Builds the container
-    docker run --rm -v $PWD=/app bobby-tables           # Builds the site
-    docker run --rm -v $PWD=/app bobby-tables make test # Runs the tests
+    docker run --rm -v $PWD:/app bobby-tables           # Builds the site to the build/ directory
+    docker run --rm -v $PWD:/app bobby-tables make test # Runs the tests
 
 Contributing page content
 -------------------------


### PR DESCRIPTION
When I was working on my other PR to add some content I wanted to generate the site to see how it looked but I didn't have Perl installed. I came up with this Dockerfile that contains all of the requirements and is capable of building the site or running the tests. By running it with `-v $PWD=/app` it mounts the current directory as a volume in the container so we can preserve the build output.

Note I had to add `--force` to the install of the test module because of some failing tests. It seems to work fine otherwise.
